### PR TITLE
Add smoke test to base python build (PYAPI-3305)

### DIFF
--- a/build_python.py
+++ b/build_python.py
@@ -3,7 +3,6 @@ import shutil
 import subprocess
 import sys
 import os
-import re
 from pathlib import Path
 
 
@@ -174,6 +173,7 @@ def main():
         install_pyenv_version(python_version)
     smoke_test()
     create_archive()
+
 
 if __name__ == "__main__":
     main()

--- a/build_python.py
+++ b/build_python.py
@@ -6,7 +6,8 @@ import os
 import re
 from pathlib import Path
 
-package_name = 'python'
+
+package_name = 'base_python'
 python_version = '3.11.6'
 macos_deployment_target = '10.15'
 
@@ -60,10 +61,19 @@ def python_destdir():
 def python_version_destdir():
     return python_destdir() / output_base_name()
 
+
+def python_interpreter():
+    if windows():
+        return python_version_destdir() / 'python.exe'
+    else:
+        return python_version_destdir() / 'bin' / 'python'
+
+
 def prepare_output_dir():
     if linux():
         subprocess.run(f'sudo mkdir -p {python_destdir()}', shell=True)
         subprocess.run(f'sudo chown $USER {python_destdir()}', shell=True)
+
 
 def install_from_msi():
     import urllib.request
@@ -124,6 +134,11 @@ def output_archive_filename():
     return f'{output_base_name()}.tar.gz'
 
 
+def smoke_test():
+    subprocess.check_call([f'{ python_interpreter() }', '-m', 'pip', 'install', 'packaging'])
+    subprocess.check_call([f'{ python_interpreter() }', 'smoke_test.py'])
+
+
 def create_archive():
     if 'BUILD_ARTIFACTSTAGINGDIRECTORY' in os.environ:
         archive_output_directory = Path(
@@ -157,6 +172,7 @@ def main():
         install_prerequisites()
         install_pyenv()
         install_pyenv_version(python_version)
+    smoke_test()
     create_archive()
 
 if __name__ == "__main__":

--- a/common-tasks.yml
+++ b/common-tasks.yml
@@ -46,7 +46,7 @@ steps:
       {
         "files": [
           {
-            "pattern": "$(Build.ArtifactStagingDirectory)/python*.tar.gz",
+            "pattern": "$(Build.ArtifactStagingDirectory)/base_python*.tar.gz",
             "target": "ccdc-3rdparty-python-interpreters/base_python/$(PythonVersion)/"
           }
         ]

--- a/smoke_test.py
+++ b/smoke_test.py
@@ -1,0 +1,21 @@
+import platform
+
+# there should be no issues importing sqlite libraries
+import sqlite3
+from packaging import version
+# Ensure we haven't inadvertently got the (ancient) system SQLite
+sqlite_version = version.parse(sqlite3.sqlite_version)
+assert version.parse('3.17.0') <= sqlite_version, f'Current version is {sqlite_version}'
+sqlite3.connect(":memory:")
+
+# pyenv has trouble building the tkinter extension, so checking for that
+# this tends to happen on macos, where even the exception handling below
+# will error out as _tkinter is not present
+# On Linux, the import can fail because DISPLAY is not set. In this case
+# a TclError is raised. But if we have that, we're good to go.
+try:
+    import tkinter
+except _tkinter.TclError:
+    print("no display, but that's ok")
+
+print('python interpreter smoke test ok')

--- a/smoke_test.py
+++ b/smoke_test.py
@@ -1,5 +1,3 @@
-import platform
-
 # there should be no issues importing sqlite libraries
 import sqlite3
 from packaging import version


### PR DESCRIPTION
Add smoke test to base python build to check that sqlite3 module version is not too old (likely problem for centos 7) and tkinter module is built (possible problem on macosx).

Also name the package "base_python".