### PR TITLE
Pyapi 3502 mac

### DIFF
--- a/build_python.py
+++ b/build_python.py
@@ -181,8 +181,8 @@ def install_pyenv_version(version):
         python_build_env['CPPFLAGS'] = f"-I/usr/local/opt/tcl-tk/include -mmacosx-version-min={macos_deployment_target}"
         python_build_env['CFLAGS'] = f"-mmacosx-version-min={macos_deployment_target}"
         python_build_env['PKG_CONFIG_PATH'] = "/usr/local/opt/tcl-tk/lib/pkgconfig"
-        #python_build_env['PYTHON_CONFIGURE_OPTS'] = "--with-tcltk-includes='-I/usr/local/opt/tcl-tk/include' --with-tcltk-libs='-L/usr/local/opt/tcl-tk/lib -ltcl8.6 -ltk8.6'"
-        subprocess.run(f"sed -i 's#\"${{!PACKAGE_CONFIGURE_OPTS_ARRAY}}\" $CONFIGURE_OPTS ${{!PACKAGE_CONFIGURE_OPTS}} || return 1#\"${{!PACKAGE_CONFIGURE_OPTS_ARRAY}}\" $CONFIGURE_OPTS --with-tcltk-includes='-I/usr/local/opt/tcl-tk/include' --with-tcltk-libs='-L/usr/local/opt/tcl-tk/lib -ltcl8.6 -ltk8.6 LDFLAGS=-L/usr/local/opt/tcl-tk/lib CPPFLAGS=\"-I/usr/local/opt/tcl-tk/include -mmacosx-version-min={macos_deployment_target}\" CFLAGS=\"-mmacosx-version-min={macos_deployment_target}\" ${{!PACKAGE_CONFIGURE_OPTS}} || return 1#' `which python-build`", shell=True, check=True, env=python_build_env)
+        python_build_env['PYTHON_CONFIGURE_OPTS'] = "--with-tcltk-includes='-I/usr/local/opt/tcl-tk/include' --with-tcltk-libs='-L/usr/local/opt/tcl-tk/lib -ltcl8.6 -ltk8.6' CFLAGS='-mmacosx-version-min={macos_deployment_target}'"
+        #subprocess.run(f"sed -i 's#\"${{!PACKAGE_CONFIGURE_OPTS_ARRAY}}\" $CONFIGURE_OPTS ${{!PACKAGE_CONFIGURE_OPTS}} || return 1#\"${{!PACKAGE_CONFIGURE_OPTS_ARRAY}}\" $CONFIGURE_OPTS --with-tcltk-includes='-I/usr/local/opt/tcl-tk/include' --with-tcltk-libs='-L/usr/local/opt/tcl-tk/lib -ltcl8.6 -ltk8.6 LDFLAGS=-L/usr/local/opt/tcl-tk/lib CPPFLAGS=\"-I/usr/local/opt/tcl-tk/include -mmacosx-version-min={macos_deployment_target}\" CFLAGS=\"-mmacosx-version-min={macos_deployment_target}\" ${{!PACKAGE_CONFIGURE_OPTS}} || return 1#' `which python-build`", shell=True, check=True, env=python_build_env)
     if linux():
         python_build_env['PATH']=f"/tmp/pyenvinst/plugins/python-build/bin:{python_build_env['PATH']}"
         if centos():

--- a/build_python.py
+++ b/build_python.py
@@ -184,7 +184,8 @@ def install_pyenv_version(version):
         python_build_env['PKG_CONFIG_PATH'] = "/usr/local/opt/tcl-tk/lib/pkgconfig"
         python_build_env['PYTHON_CONFIGURE_OPTS'] = "--with-tcltk-includes='-I/usr/local/opt/tcl-tk/include' --with-tcltk-libs='-L/usr/local/opt/tcl-tk/lib -ltcl8.6 -ltk8.6' --with-macosx-version-min={macos_deployment_target}"
         python_build_env['CONFIGURE_OPTS'] = "--with-macosx-version-min={macos_deployment_target}"
-        #subprocess.run(f"sed -i 's#\"${{!PACKAGE_CONFIGURE_OPTS_ARRAY}}\" $CONFIGURE_OPTS ${{!PACKAGE_CONFIGURE_OPTS}} || return 1#\"${{!PACKAGE_CONFIGURE_OPTS_ARRAY}}\" $CONFIGURE_OPTS --with-tcltk-includes='-I/usr/local/opt/tcl-tk/include' --with-tcltk-libs='-L/usr/local/opt/tcl-tk/lib -ltcl8.6 -ltk8.6 LDFLAGS=-L/usr/local/opt/tcl-tk/lib CPPFLAGS=\"-I/usr/local/opt/tcl-tk/include -mmacosx-version-min={macos_deployment_target}\" CFLAGS=\"-mmacosx-version-min={macos_deployment_target}\" ${{!PACKAGE_CONFIGURE_OPTS}} || return 1#' `which python-build`", shell=True, check=True, env=python_build_env)
+        subprocess.run(f'sudo -E python-build {version} {python_version_destdir()}', shell=True, check=True, env=python_build_env)
+        return
     if linux():
         python_build_env['PATH']=f"/tmp/pyenvinst/plugins/python-build/bin:{python_build_env['PATH']}"
         if centos():

--- a/build_python.py
+++ b/build_python.py
@@ -177,8 +177,9 @@ def install_pyenv_version(version):
     python_build_env = dict(os.environ)
     if macos():
         python_build_env['PATH'] = f"/usr/local/opt/tcl-tk/bin:{python_build_env['PATH']}"
-        python_build_env['LDFLAGS'] = f"-L/usr/local/opt/tcl-tk/lib -mmacosx-version-min={macos_deployment_target} -weak_reference_mismatches weak"
+        python_build_env['LDFLAGS'] = f"-L/usr/local/opt/tcl-tk/lib"
         python_build_env['CPPFLAGS'] = f"-I/usr/local/opt/tcl-tk/include -mmacosx-version-min={macos_deployment_target}"
+        python_build_env['CFLAGS'] = f"-mmacosx-version-min={macos_deployment_target}"
         python_build_env['PKG_CONFIG_PATH'] = "/usr/local/opt/tcl-tk/lib/pkgconfig"
         python_build_env['PYTHON_CONFIGURE_OPTS'] = "--with-tcltk-includes='-I/usr/local/opt/tcl-tk/include' --with-tcltk-libs='-L/usr/local/opt/tcl-tk/lib -ltcl8.6 -ltk8.6'"
     if linux():

--- a/build_python.py
+++ b/build_python.py
@@ -178,12 +178,12 @@ def install_pyenv_version(version):
     if macos():
         python_build_env['PATH'] = f"/usr/local/opt/tcl-tk/bin:{python_build_env['PATH']}"
         python_build_env['MACOSX_DEPLOYMENT_TARGET'] = macos_deployment_target
-        python_build_env['LDFLAGS'] = f"-L/usr/local/opt/tcl-tk/lib"
+        python_build_env['LDFLAGS'] = "-L/usr/local/opt/tcl-tk/lib"
         python_build_env['CPPFLAGS'] = f"-I/usr/local/opt/tcl-tk/include -mmacosx-version-min={macos_deployment_target}"
         python_build_env['CFLAGS'] = f"-mmacosx-version-min={macos_deployment_target}"
         python_build_env['PKG_CONFIG_PATH'] = "/usr/local/opt/tcl-tk/lib/pkgconfig"
-        python_build_env['PYTHON_CONFIGURE_OPTS'] = "--with-tcltk-includes='-I/usr/local/opt/tcl-tk/include' --with-tcltk-libs='-L/usr/local/opt/tcl-tk/lib -ltcl8.6 -ltk8.6' --with-macosx-version-min={macos_deployment_target}"
-        python_build_env['CONFIGURE_OPTS'] = "--with-macosx-version-min={macos_deployment_target}"
+        python_build_env['PYTHON_CONFIGURE_OPTS'] = f"--with-tcltk-includes='-I/usr/local/opt/tcl-tk/include' --with-tcltk-libs='-L/usr/local/opt/tcl-tk/lib -ltcl8.6 -ltk8.6' --with-macosx-version-min={macos_deployment_target}"
+        python_build_env['CONFIGURE_OPTS'] = f"--with-macosx-version-min={macos_deployment_target}"
         subprocess.run(f'sudo -E python-build {version} {python_version_destdir()}', shell=True, check=True, env=python_build_env)
         return
     if linux():

--- a/build_python.py
+++ b/build_python.py
@@ -177,7 +177,7 @@ def install_pyenv_version(version):
     python_build_env = dict(os.environ)
     if macos():
         python_build_env['PATH'] = f"/usr/local/opt/tcl-tk/bin:{python_build_env['PATH']}"
-        python_build_env['LDFLAGS'] = f"-L/usr/local/opt/tcl-tk/lib -mmacosx-version-min={macos_deployment_target}"
+        python_build_env['LDFLAGS'] = f"-L/usr/local/opt/tcl-tk/lib -mmacosx-version-min={macos_deployment_target} -weak_reference_mismatches weak"
         python_build_env['CPPFLAGS'] = f"-I/usr/local/opt/tcl-tk/include -mmacosx-version-min={macos_deployment_target}"
         python_build_env['PKG_CONFIG_PATH'] = "/usr/local/opt/tcl-tk/lib/pkgconfig"
         python_build_env['PYTHON_CONFIGURE_OPTS'] = "--with-tcltk-includes='-I/usr/local/opt/tcl-tk/include' --with-tcltk-libs='-L/usr/local/opt/tcl-tk/lib -ltcl8.6 -ltk8.6'"

--- a/build_python.py
+++ b/build_python.py
@@ -181,7 +181,8 @@ def install_pyenv_version(version):
         python_build_env['CPPFLAGS'] = f"-I/usr/local/opt/tcl-tk/include -mmacosx-version-min={macos_deployment_target}"
         python_build_env['CFLAGS'] = f"-mmacosx-version-min={macos_deployment_target}"
         python_build_env['PKG_CONFIG_PATH'] = "/usr/local/opt/tcl-tk/lib/pkgconfig"
-        python_build_env['PYTHON_CONFIGURE_OPTS'] = "--with-tcltk-includes='-I/usr/local/opt/tcl-tk/include' --with-tcltk-libs='-L/usr/local/opt/tcl-tk/lib -ltcl8.6 -ltk8.6' CFLAGS='-mmacosx-version-min={macos_deployment_target}'"
+        python_build_env['PYTHON_CONFIGURE_OPTS'] = "--with-tcltk-includes='-I/usr/local/opt/tcl-tk/include' --with-tcltk-libs='-L/usr/local/opt/tcl-tk/lib -ltcl8.6 -ltk8.6' CFLAGS='-mmacosx-version-min={macos_deployment_target}' CPPFLAGS='-mmacosx-version-min={macos_deployment_target}'"
+        python_build_env['CONFIGURE_OPTS'] = "CFLAGS='-mmacosx-version-min={macos_deployment_target}' CPPFLAGS='-mmacosx-version-min={macos_deployment_target}'"
         #subprocess.run(f"sed -i 's#\"${{!PACKAGE_CONFIGURE_OPTS_ARRAY}}\" $CONFIGURE_OPTS ${{!PACKAGE_CONFIGURE_OPTS}} || return 1#\"${{!PACKAGE_CONFIGURE_OPTS_ARRAY}}\" $CONFIGURE_OPTS --with-tcltk-includes='-I/usr/local/opt/tcl-tk/include' --with-tcltk-libs='-L/usr/local/opt/tcl-tk/lib -ltcl8.6 -ltk8.6 LDFLAGS=-L/usr/local/opt/tcl-tk/lib CPPFLAGS=\"-I/usr/local/opt/tcl-tk/include -mmacosx-version-min={macos_deployment_target}\" CFLAGS=\"-mmacosx-version-min={macos_deployment_target}\" ${{!PACKAGE_CONFIGURE_OPTS}} || return 1#' `which python-build`", shell=True, check=True, env=python_build_env)
     if linux():
         python_build_env['PATH']=f"/tmp/pyenvinst/plugins/python-build/bin:{python_build_env['PATH']}"

--- a/build_python.py
+++ b/build_python.py
@@ -182,7 +182,11 @@ def install_pyenv_version(version):
         python_build_env['CPPFLAGS'] = f"-I/usr/local/opt/tcl-tk/include -mmacosx-version-min={macos_deployment_target}"
         python_build_env['CFLAGS'] = f"-mmacosx-version-min={macos_deployment_target}"
         python_build_env['PKG_CONFIG_PATH'] = "/usr/local/opt/tcl-tk/lib/pkgconfig"
-        python_build_env['PYTHON_CONFIGURE_OPTS'] = f"--with-tcltk-includes='-I/usr/local/opt/tcl-tk/include' --with-tcltk-libs='-L/usr/local/opt/tcl-tk/lib -ltcl8.6 -ltk8.6' --with-macosx-version-min={macos_deployment_target}"
+        python_build_env['PYTHON_CONFIGURE_OPTS'] = (
+                "--with-tcltk-includes='-I/usr/local/opt/tcl-tk/include' "
+                "--with-tcltk-libs='-L/usr/local/opt/tcl-tk/lib -ltcl8.6 -ltk8.6' "
+                f"--with-macosx-version-min={macos_deployment_target}"
+                )
         python_build_env['CONFIGURE_OPTS'] = f"--with-macosx-version-min={macos_deployment_target}"
         subprocess.run(f'sudo -E python-build {version} {python_version_destdir()}', shell=True, check=True, env=python_build_env)
         return

--- a/build_python.py
+++ b/build_python.py
@@ -177,12 +177,13 @@ def install_pyenv_version(version):
     python_build_env = dict(os.environ)
     if macos():
         python_build_env['PATH'] = f"/usr/local/opt/tcl-tk/bin:{python_build_env['PATH']}"
+        python_build_env['MACOSX_DEPLOYMENT_TARGET'] = macos_deployment_target
         python_build_env['LDFLAGS'] = f"-L/usr/local/opt/tcl-tk/lib"
         python_build_env['CPPFLAGS'] = f"-I/usr/local/opt/tcl-tk/include -mmacosx-version-min={macos_deployment_target}"
         python_build_env['CFLAGS'] = f"-mmacosx-version-min={macos_deployment_target}"
         python_build_env['PKG_CONFIG_PATH'] = "/usr/local/opt/tcl-tk/lib/pkgconfig"
-        python_build_env['PYTHON_CONFIGURE_OPTS'] = "--with-tcltk-includes='-I/usr/local/opt/tcl-tk/include' --with-tcltk-libs='-L/usr/local/opt/tcl-tk/lib -ltcl8.6 -ltk8.6' CFLAGS='-mmacosx-version-min={macos_deployment_target}' CPPFLAGS='-mmacosx-version-min={macos_deployment_target}'"
-        python_build_env['CONFIGURE_OPTS'] = "CFLAGS='-mmacosx-version-min={macos_deployment_target}' CPPFLAGS='-mmacosx-version-min={macos_deployment_target}'"
+        python_build_env['PYTHON_CONFIGURE_OPTS'] = "--with-tcltk-includes='-I/usr/local/opt/tcl-tk/include' --with-tcltk-libs='-L/usr/local/opt/tcl-tk/lib -ltcl8.6 -ltk8.6' --with-macosx-version-min={macos_deployment_target}"
+        python_build_env['CONFIGURE_OPTS'] = "--with-macosx-version-min={macos_deployment_target}"
         #subprocess.run(f"sed -i 's#\"${{!PACKAGE_CONFIGURE_OPTS_ARRAY}}\" $CONFIGURE_OPTS ${{!PACKAGE_CONFIGURE_OPTS}} || return 1#\"${{!PACKAGE_CONFIGURE_OPTS_ARRAY}}\" $CONFIGURE_OPTS --with-tcltk-includes='-I/usr/local/opt/tcl-tk/include' --with-tcltk-libs='-L/usr/local/opt/tcl-tk/lib -ltcl8.6 -ltk8.6 LDFLAGS=-L/usr/local/opt/tcl-tk/lib CPPFLAGS=\"-I/usr/local/opt/tcl-tk/include -mmacosx-version-min={macos_deployment_target}\" CFLAGS=\"-mmacosx-version-min={macos_deployment_target}\" ${{!PACKAGE_CONFIGURE_OPTS}} || return 1#' `which python-build`", shell=True, check=True, env=python_build_env)
     if linux():
         python_build_env['PATH']=f"/tmp/pyenvinst/plugins/python-build/bin:{python_build_env['PATH']}"

--- a/build_python.py
+++ b/build_python.py
@@ -181,7 +181,8 @@ def install_pyenv_version(version):
         python_build_env['CPPFLAGS'] = f"-I/usr/local/opt/tcl-tk/include -mmacosx-version-min={macos_deployment_target}"
         python_build_env['CFLAGS'] = f"-mmacosx-version-min={macos_deployment_target}"
         python_build_env['PKG_CONFIG_PATH'] = "/usr/local/opt/tcl-tk/lib/pkgconfig"
-        python_build_env['PYTHON_CONFIGURE_OPTS'] = "--with-tcltk-includes='-I/usr/local/opt/tcl-tk/include' --with-tcltk-libs='-L/usr/local/opt/tcl-tk/lib -ltcl8.6 -ltk8.6'"
+        #python_build_env['PYTHON_CONFIGURE_OPTS'] = "--with-tcltk-includes='-I/usr/local/opt/tcl-tk/include' --with-tcltk-libs='-L/usr/local/opt/tcl-tk/lib -ltcl8.6 -ltk8.6'"
+        subprocess.run(f"sed -i 's#\"${{!PACKAGE_CONFIGURE_OPTS_ARRAY}}\" $CONFIGURE_OPTS ${{!PACKAGE_CONFIGURE_OPTS}} || return 1#\"${{!PACKAGE_CONFIGURE_OPTS_ARRAY}}\" $CONFIGURE_OPTS --with-tcltk-includes='-I/usr/local/opt/tcl-tk/include' --with-tcltk-libs='-L/usr/local/opt/tcl-tk/lib -ltcl8.6 -ltk8.6 LDFLAGS=-L/usr/local/opt/tcl-tk/lib CPPFLAGS=\"-I/usr/local/opt/tcl-tk/include -mmacosx-version-min={macos_deployment_target}\" CFLAGS=\"-mmacosx-version-min={macos_deployment_target}\" ${{!PACKAGE_CONFIGURE_OPTS}} || return 1#' `which python-build`", shell=True, check=True, env=python_build_env)
     if linux():
         python_build_env['PATH']=f"/tmp/pyenvinst/plugins/python-build/bin:{python_build_env['PATH']}"
         if centos():


### PR DESCRIPTION
Use both the MACOSX_DEPLOYMENT_TARGET env var and the command line option "macosx-version-min" to ensure that the mac build of base python can still work on our existing build VMs, which are currently macosx 10.15.